### PR TITLE
Bug fix in scope processing

### DIFF
--- a/pyDigitalWaveTools/tests/vcdParser_test.py
+++ b/pyDigitalWaveTools/tests/vcdParser_test.py
@@ -18,17 +18,17 @@ class VcdParserUnitTest(unittest.TestCase):
                         {
                             "name": "sig0",
                             "type": {"name": "wire", "width": 1},
-                            "children": [(0, "X"), (1, "0")],
+                            "data": [(0, "X"), (1, "0")],
                         },
                         {
                             "name": "sig1",
                             "type": {"name": "wire", "width": 1},
-                            "children": [(0, "X"), (2, "1")],
+                            "data": [(0, "X"), (2, "1")],
                         },
                         {
                             "name": "vect0",
                             "type": {"name": "wire", "width": 16},
-                            "children": [(0, "bXXXXXXXXXXXXXXXX"), (3, "b0000000000001010"), (4, "b0000000000010100")],
+                            "data": [(0, "bXXXXXXXXXXXXXXXX"), (3, "b0000000000001010"), (4, "b0000000000010100")],
                         },
                     ]
                 }

--- a/pyDigitalWaveTools/tests/vcdParser_test.py
+++ b/pyDigitalWaveTools/tests/vcdParser_test.py
@@ -8,24 +8,30 @@ class VcdParserUnitTest(unittest.TestCase):
     def test_example0(self):
         fIn = os.path.join(BASE, "example0.vcd")
         reference = {
-            "name": "unit0",
+            "name": "root",
             "type": {"sigType": "struct"},
             "data": [
                 {
-                    "name": "sig0",
-                    "type": {"sigType": "wire", "width": 1},
-                    "data": [(0, "X"), (1, "0")],
-                },
-                {
-                    "name": "sig1",
-                    "type": {"sigType": "wire", "width": 1},
-                    "data": [(0, "X"), (2, "1")],
-                },
-                {
-                    "name": "vect0",
-                    "type": {"sigType": "wire", "width": 16},
-                    "data": [(0, "bXXXXXXXXXXXXXXXX"), (3, "b0000000000001010"), (4, "b0000000000010100")],
-                },
+                    "name": "unit0",
+                    "type": {"sigType": "struct"},
+                    "data": [
+                        {
+                            "name": "sig0",
+                            "type": {"sigType": "wire", "width": 1},
+                            "data": [(0, "X"), (1, "0")],
+                        },
+                        {
+                            "name": "sig1",
+                            "type": {"sigType": "wire", "width": 1},
+                            "data": [(0, "X"), (2, "1")],
+                        },
+                        {
+                            "name": "vect0",
+                            "type": {"sigType": "wire", "width": 16},
+                            "data": [(0, "bXXXXXXXXXXXXXXXX"), (3, "b0000000000001010"), (4, "b0000000000010100")],
+                        },
+                    ]
+                }
             ]
         }
 

--- a/pyDigitalWaveTools/vcd/parser.py
+++ b/pyDigitalWaveTools/vcd/parser.py
@@ -179,23 +179,18 @@ class VcdParser(object):
         assert scopeType[1] == "module", scopeType
         scopeName = next(tokeniser)
         assert next(tokeniser)[1] == "$end"
-        if self.scope is None:
-            self.scope = VcdVarScope(scopeName[1], self.scope)
+        if scopeName[1] in self.scope.children:
+            # TODO: handling for cases when both module and var of the same name
+            # exists in one scope
+            assert(isinstance(self.scope.children[scopeName[1]], VcdVarScope))
+            self.scope = self.scope.children[scopeName[1]]
         else:
-            if scopeName[1] in self.scope.children:
-                # TODO: handling for cases when both module and var of the same name
-                # exists in one scope
-                assert(isinstance(self.scope.children[scopeName[1]], VcdVarScope))
-                self.scope = self.scope.children[scopeName[1]]
-            else:
-                new_scope = VcdVarScope(scopeName[1], self.scope)
-                self.scope.children[scopeName[1]] = new_scope
-                self.scope = new_scope
+            new_scope = VcdVarScope(scopeName[1], self.scope)
+            self.scope.children[scopeName[1]] = new_scope
+            self.scope = new_scope
 
     def vcd_upscope(self, tokeniser, keyword):
-        p = self.scope.parent
-        if p is not None:
-            self.scope = p
+        self.scope = self.scope.parent
         assert next(tokeniser)[1] == "$end"
 
     def vcd_var(self, tokeniser, keyword):


### PR DESCRIPTION
Hi,

Thank you for your python library! I've found the library very useful as I'm working on a VCD comparator written in Python.

I've found the library not behaving as expected when I used things like `$dumpvars(0, x, y);` in iVerilog simulator. This commit now adds a "root" scope on top of the internal hierarchy, and fixes the problem in this vcd piece:

$scope module testbench $end
$var reg 3 ! x [2:0] $end
$upscope $end
$scope module testbench $end
$var wire 8 " y [7:0] $end
$upscope $end
$enddefinitions $end

Also, this commit fixed nesting scope like this:
$scope module aaa $end
$var .. $end
$scope module bbb $end
$var .. $end
$upscope $end
$upscope $end
$enddefinitions $end

However, my commits broke backward compatibility a little bit, so if you've found it useful you might need to bump the package version for indication.

Thanks,
Libre Liu